### PR TITLE
Tidy up recipe

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,7 +8,7 @@ copy %RECIPE_DIR%\menu-windows.json %MENU_DIR%\ovito.json
 
 :: Configure using the CMakeFiles
 cmake -G "NMake Makefiles" ^
-      -D Python3_ROOT_DIR=%PREFIX% ^
+      -D Python3_ROOT_DIR=%BUILD_PREFIX% ^
       -D Python3_FIND_STRATEGY=LOCATION ^
       -D Python3_FIND_VIRTUALENV=ONLY ^
       -D Python3_EXECUTABLE=%PYTHON% ^
@@ -22,8 +22,6 @@ cmake -G "NMake Makefiles" ^
       -D CMAKE_BUILD_TYPE=Release ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
-      -D Python3_FIND_REGISTRY=NEVER ^
-      -D Python3_FIND_STRATEGY=LOCATION ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,7 @@ if [[ -n "$MACOSX_DEPLOYMENT_TARGET" ]]; then
 fi
 
 cmake ${CMAKE_ARGS} -DOVITO_BUILD_DOCUMENTATION=ON \
-      -DPython3_ROOT_DIR="${PREFIX}" \
+      -DPython3_ROOT_DIR="${BUILD_PREFIX}" \
       -DPython3_FIND_STRATEGY=LOCATION \
       -DPython3_FIND_VIRTUALENV=ONLY \
       -DPython3_EXECUTABLE=${PYTHON} \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - boost-cpp
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,11 +46,8 @@ requirements:
     - zlib
     - sphinx
     - sphinx_rtd_theme
-  run:
-    # nettle from defaults is not compatible
-    - {{ pin_compatible('nettle', exact=True) }}  # [unix]
   run_constrained:
-    - menuinst >=1.4.17
+    - menuinst >=1.4.17  # [win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,12 +29,7 @@ requirements:
     - {{ cdt('mesa-libgl-devel') }}  # [linux]
     - {{ cdt('mesa-dri-drivers') }}  # [linux]
     - cmake
-    # Mac OS needs specific boost restrictions - temporarily 
-    # https://github.com/conda-forge/boost-cpp-feedstock/issues/134
-    # https://github.com/conda-forge/libcxx-feedstock/issues/114
-    - boost-cpp  # [linux]
-    - boost-cpp  # [win]
-    - boost-cpp >=1.81  # [osx]
+    - boost-cpp
     - make  # [unix]
     - python                                # [build_platform != target_platform]
     - cross-python_{{ target_platform }}    # [build_platform != target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,16 +31,14 @@ requirements:
     - cmake
     - boost-cpp
     - make  # [unix]
-    - python                                # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}    # [build_platform != target_platform]
+    - sphinx
+    - sphinx_rtd_theme
     - qt6-main                              # [build_platform != target_platform]
   host:
     - ffmpeg
     - libnetcdf
     - qt6-main
     - zlib
-    - sphinx
-    - sphinx_rtd_theme
   run_constrained:
     - menuinst >=1.4.17  # [win]
 


### PR DESCRIPTION
I have been looking at removing the python dependency on the osx-arm64 build and noticed that the recipe doesn't build with qt 6.5: commit 02842b547a6adccb61ea9060592d5d7d259b618c will shows the error and I will push another commit with the qt6-main pinned to 6.4 to fix the build.

- Specify win selector to `run_constrained` on menuinst.
- Remove unnecessary nettle run_constrained.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [n/a] Reset the build number to `0` (if the version changed)
* [n/a] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [n/a] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
